### PR TITLE
Use specifiers to indicate dependence on ordereddict for python2.6 only

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,14 +16,10 @@ readme_filename = os.path.join(os.path.dirname(__file__), 'README.rst')
 with codecs.open(readme_filename, encoding='utf8') as ld_file:
     long_description = ld_file.read()
 
-requirements = []
-
 if sys.version_info[0] == 2:
     # bail on UTF-8 and enable `import configparser` for Python 2
     author = 'Lukasz Langa'
     modules = ['configparser']
-    if sys.version_info[1] < 7:
-        requirements.append('ordereddict')
 else:
     author = 'Łukasz Langa'
     modules = []
@@ -46,7 +42,7 @@ setup(
     packages=find_packages('src'),
     include_package_data=True,
     zip_safe=False,
-    install_requires=requirements,
+    extras_require={':python_version=="2.6"': ['ordereddict']},
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Without this, a wheel built in python2 will have incorrect dependencies: - A wheel built with python2.7 will produce a py2-none-any wheel which is a proper installation candidate for a python2.6 pip, but this wheel will not have the ordereddict dependency - A wheel built with python2.6 will produce a py2-none-any wheel which is a proper installation candidate for python2.7 pip, but will unnecessarily install ordereddict.

To read more about these markers: - https://www.python.org/dev/peps/pep-0426/#environment-markers

For the version specifiers to be honored: - Install from a wheel (requires pip>1.4 (Released in 2013 (ancient)) - Install from a sdist (requires pip>=6 (Released December 2014))