### PR TITLE
Only produce python3 warning with python3 warnings enabled

### DIFF
--- a/src/backports/configparser/__init__.py
+++ b/src/backports/configparser/__init__.py
@@ -684,7 +684,7 @@ class RawConfigParser(MutableMapping):
 
         Return list of successfully read files.
         """
-        if PY2 and isinstance(filenames, bytes):
+        if PY2 and isinstance(filenames, bytes) and sys.py3kwarning:
             # we allow for a little unholy magic for Python 2 so that
             # people not using unicode_literals can still use the library
             # conveniently


### PR DESCRIPTION
As it is, this warning is quite difficult to avoid in a number of circumstances that would automatically be fixed in python3.x. As such, this warning is often not useful. Here’s a few examples where I’ve encountered this that are a bit annoying to fix:

- flake8: takes commandline arguments (sys.argv is native strings (bytes py2, str py3)) which are passed to configparser
- flake8: passes string literals to configparser (string literals are native strings)
- entrypoints: passes os.path.join(sys.path entry, …) to configparser (sys.path is native strings)

‌

These warnings only appear in python2.x and any sane library is already testing against python3.x where these would be errors.

‌

As such, I propose either outright removing this warning, or (as this PR does) guarding it by `sys.py3kwarning` which is only `True` when running with `python2 -3 ...`