### PR TITLE
Unconditionally install configparser shim

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[bdist_wheel]
+universal = 1
+
 [metadata]
 name=configparser
 version=3.7.1
@@ -33,3 +36,4 @@ install_requires =
 	ordereddict; python_version=="2.6"
 include_package_data = True
 python_requires = >=2.6
+py_modules = configparser

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,6 @@
-import sys
 import setuptools
 
 setuptools.setup(
-    # enable `import configparser` for Python 2
-    py_modules=['configparser'] if sys.version_info < (3,) else [],
     packages=setuptools.find_packages(where='src'),
     package_dir={'': 'src'},
 )


### PR DESCRIPTION
Let sys.path preference of stdlib over site-packages give precedence to default module. Allows for universal wheel.