### PR TITLE
Restore Windows tests on older Pythons

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,10 +56,6 @@ jobs:
           platform: ubuntu-latest
         - python: pypy3.9
           platform: ubuntu-latest
-        exclude:
-        # pip 21 chokes on non-ascii in setup.cfg (#67)
-        - python: "3.8"
-          platform: windows-latest
     runs-on: ${{ matrix.platform }}
     continue-on-error: ${{ matrix.python == '3.12' }}
     steps:

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ toxworkdir={env:TOX_WORK_DIR:.tox}
 [testenv]
 deps =
 	# workaround for #67
-	pip >= 23; platform_system == "Windows" and python_version < "3.9"
+	virtualenv; platform_system == "Windows" and python_version < "3.9"
 setenv =
 	PYTHONWARNDEFAULTENCODING = 1
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,8 @@ toxworkdir={env:TOX_WORK_DIR:.tox}
 
 [testenv]
 deps =
+	# workaround for #67
+	pip >= 23; platform_system == "Windows" and python_version < "3.9"
 setenv =
 	PYTHONWARNDEFAULTENCODING = 1
 commands =


### PR DESCRIPTION
- Bump pip as more durable remedy for #67.
- Rely on virtualenv as more surgical workaround for #67.
